### PR TITLE
Update for TEDP2 Phase 2, REX Voting Requirement Removal

### DIFF
--- a/contracts/eosio.system/src/delegate_bandwidth.cpp
+++ b/contracts/eosio.system/src/delegate_bandwidth.cpp
@@ -48,7 +48,7 @@ namespace eosiosystem {
    void system_contract::buyram( const name& payer, const name& receiver, const asset& quant )
    {
       require_auth( payer );
-      // update_ram_supply();
+      update_ram_supply();
 
       check( quant.symbol == core_symbol(), "must buy ram with core token" );
       check( quant.amount > 0, "must purchase a positive amount" );
@@ -115,7 +115,7 @@ namespace eosiosystem {
     */
    void system_contract::sellram( const name& account, int64_t bytes ) {
       require_auth( account );
-      // update_ram_supply();
+      update_ram_supply();
 
       check( bytes > 0, "cannot sell negative byte" );
 

--- a/contracts/eosio.system/src/producer_pay.cpp
+++ b/contracts/eosio.system/src/producer_pay.cpp
@@ -172,16 +172,16 @@ namespace eosiosystem {
         
         uint32_t sharecount = 0;
 
-        //calculate shares, should be between 2 and 72 shares
+        //calculate shares, should be between 2 and 72 shares - Updated for TEDP2 with 21 BPs + 21 paid standbys
         for (const auto &prod : sortedprods)
         {
             if (prod.active()) { 			//only count activated producers
                 if (sharecount <= 42) {
                     sharecount += 2; 		//top producers count as double shares
-                } else if (sharecount >= 43 && sharecount < 72) {
+                } else if (sharecount >= 43 && sharecount < 63) {    //next 21 BPs get single share each
                     sharecount++;
                 } else
-                    break; 					//no need to count past 72 shares
+                    break; 					//no need to count past 63 shares
             }
         }
         

--- a/contracts/eosio.system/src/producer_pay.cpp
+++ b/contracts/eosio.system/src/producer_pay.cpp
@@ -177,7 +177,7 @@ namespace eosiosystem {
         for (const auto &prod : sortedprods)
         {
             if (prod.active() && activecount < MAX_PRODUCERS)   //only count activated producers
-                activecount++
+                activecount++;
             else
                 break;
         }

--- a/contracts/eosio.system/src/rex.cpp
+++ b/contracts/eosio.system/src/rex.cpp
@@ -42,7 +42,7 @@ namespace eosiosystem {
 
       check( amount.symbol == core_symbol(), "asset must be core token" );
       check( 0 < amount.amount, "must use positive amount" );
-      check_voting_requirement( from );
+      // check_voting_requirement( from );            Remove requirement to vote 21 BPs or select a proxy to stake to REX
       transfer_from_fund( from, amount );
       const asset rex_received    = add_to_rex_pool( amount );
       const asset delta_rex_stake = add_to_rex_balance( from, amount, rex_received );
@@ -60,7 +60,7 @@ namespace eosiosystem {
       check( from_net.symbol == core_symbol() && from_cpu.symbol == core_symbol(), "asset must be core token" );
       check( (0 <= from_net.amount) && (0 <= from_cpu.amount) && (0 < from_net.amount || 0 < from_cpu.amount),
              "must unstake a positive amount to buy rex" );
-      check_voting_requirement( owner );
+      // check_voting_requirement( owner );            Remove requirement to vote 21 BPs or select a proxy to stake to REX 
 
       {
          del_bandwidth_table dbw_table( get_self(), owner.value );
@@ -420,7 +420,7 @@ namespace eosiosystem {
    void system_contract::check_voting_requirement( const name& owner, const char* error_msg )const
    {
       auto vitr = _voters.find( owner.value );
-      check( vitr != _voters.end() && ( vitr->proxy || 21 <= vitr->producers.size() ), error_msg );
+      check( vitr != _voters.end() && ( vitr->proxy || 0 <= vitr->producers.size() ), error_msg );       // Required voters set to 0 
    }
 
    /**

--- a/contracts/eosio.system/src/rex.cpp
+++ b/contracts/eosio.system/src/rex.cpp
@@ -420,7 +420,7 @@ namespace eosiosystem {
    void system_contract::check_voting_requirement( const name& owner, const char* error_msg )const
    {
       auto vitr = _voters.find( owner.value );
-      check( vitr != _voters.end() && ( vitr->proxy || 0 <= vitr->producers.size() ), error_msg );       // Required voters set to 0 
+      check( vitr != _voters.end() && ( vitr->proxy || 21 <= vitr->producers.size() ), error_msg ); 
    }
 
    /**

--- a/contracts/eosio.system/src/system_rotation.cpp
+++ b/contracts/eosio.system/src/system_rotation.cpp
@@ -5,7 +5,7 @@
 #define ONE_HOUR_US 900000000       // debug version
 #define SIX_MINUTES_US 360000000    // debug version
 #define TWELVE_MINUTES_US 720000000 // debug version
-#define MAX_PRODUCERS 51
+#define MAX_PRODUCERS 42     // revised for TEDP 2 Phase 2
 #define TOP_PRODUCERS 21
 #define MAX_VOTE_PRODUCERS 30
 

--- a/contracts/eosio.system/src/system_rotation.cpp
+++ b/contracts/eosio.system/src/system_rotation.cpp
@@ -5,7 +5,7 @@
 #define ONE_HOUR_US 900000000       // debug version
 #define SIX_MINUTES_US 360000000    // debug version
 #define TWELVE_MINUTES_US 720000000 // debug version
-#define MAX_PRODUCERS 42     // revised for TEDP 2 Phase 2
+#define MAX_PRODUCERS 42     // revised for TEDP 2 Phase 2, also set in producer_pay.cpp, change in both places
 #define TOP_PRODUCERS 21
 #define MAX_VOTE_PRODUCERS 30
 

--- a/contracts/eosio.system/src/voting.cpp
+++ b/contracts/eosio.system/src/voting.cpp
@@ -140,10 +140,10 @@ namespace eosiosystem {
       require_auth( voter_name );
       vote_stake_updater( voter_name );
       update_votes( voter_name, proxy, producers, true );
-      auto rex_itr = _rexbalance.find( voter_name.value );
-      if( rex_itr != _rexbalance.end() && rex_itr->rex_balance.amount > 0 ) {
-         check_voting_requirement( voter_name, "voter holding REX tokens must vote for at least 21 producers or for a proxy" );
-      }
+      // auto rex_itr = _rexbalance.find( voter_name.value );            Remove requirement to vote 21 BPs or select a proxy to stake to REX
+      // if( rex_itr != _rexbalance.end() && rex_itr->rex_balance.amount > 0 ) {
+      //    check_voting_requirement( voter_name, "voter holding REX tokens must vote for at least 21 producers or for a proxy" );
+      // }
    }
 
    void system_contract::update_votes( const name& voter_name, const name& proxy, const std::vector<name>& producers, bool voting ) {


### PR DESCRIPTION
## Change Description
- Revise BP shares counting with 21 paid standby BPs instead of 30 per TEDP2 Phase 2

- Revise voting and REX to remove the requirement that an account vote for 21 BPs or select a proxy in order to stake TLOS to REX

## Deployment Changes
- [x] Deployment Changes

### TEDP2 Phase 2 Changes

- `producer_pay.cpp` is changed to pay only 21 standby BPs instead of 30.

- `system_rotation.cpp` is changed to define the maximum number of BPs (top 21 + paid standbys) to be included in auto-rotation to 42.

### REX Voting/Proxying Requirement Removal

- `rex.cpp` is changed to remove calls to `check_voting_requirement` and to set the number of producers required by `check_voting_requirement` to zero.

- `voting.cpp` is changed to remove the check of REX balance when voting.

## API Changes
- [ ] API Changes



## Documentation Additions
- [ ] Documentation Additions

