### PR TITLE
Add clean action to reset the config

### DIFF
--- a/contracts/telos.tfvt/include/telos.tfvt.hpp
+++ b/contracts/telos.tfvt/include/telos.tfvt.hpp
@@ -159,6 +159,8 @@ public:
 	config_table configs;
   	config _config;
 
+    [[eosio::action]]
+    void clean();
 
     [[eosio::action]] //NOTE: sends inline actions to register and initialize TFVT token registry
     void inittfvt(string initial_info_link);

--- a/contracts/telos.tfvt/src/telos.tfvt.cpp
+++ b/contracts/telos.tfvt/src/telos.tfvt.cpp
@@ -33,6 +33,11 @@ tfvt::config tfvt::get_default_config() {
 
 #pragma region Actions
 
+void tfvt::clean() {
+    require_auth(get_self());
+    configs.remove();
+}
+
 void tfvt::inittfvt(string initial_info_link) {
     require_auth(get_self());
     


### PR DESCRIPTION

## Change Description
Adds a clean command for removing the current config - Used to update to the next major version of this contract: https://github.com/telosnetwork/telos-board

## Deployment Changes
- [ ] Deployment Changes


## API Changes
- [X] API Changes
adds new `clean action`

## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
