### PR TITLE
Update msig contract

### DIFF
--- a/contracts/eosio.msig/CMakeLists.txt
+++ b/contracts/eosio.msig/CMakeLists.txt
@@ -1,12 +1,12 @@
 add_contract(eosio.msig eosio.msig ${CMAKE_CURRENT_SOURCE_DIR}/src/eosio.msig.cpp)
 
 target_include_directories(eosio.msig
-   PUBLIC
-   ${CMAKE_CURRENT_SOURCE_DIR}/include)
+        PUBLIC
+        ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
 set_target_properties(eosio.msig
-   PROPERTIES
-   RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}")
+        PROPERTIES
+        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}")
 
 configure_file( ${CMAKE_CURRENT_SOURCE_DIR}/ricardian/eosio.msig.contracts.md.in ${CMAKE_CURRENT_BINARY_DIR}/ricardian/eosio.msig.contracts.md @ONLY )
 

--- a/contracts/eosio.msig/include/eosio.msig/eosio.msig.hpp
+++ b/contracts/eosio.msig/include/eosio.msig/eosio.msig.hpp
@@ -6,169 +6,157 @@
 #include <eosio/transaction.hpp>
 
 namespace eosio {
-   /**
-    * @defgroup eosiomsig eosio.msig
-    * @ingroup eosiocontracts
-    * eosio.msig contract defines the structures and actions needed to manage the proposals and approvals on blockchain.
-    * @{
-    */
-   class [[eosio::contract("eosio.msig")]] multisig : public contract {
-      public:
-         using contract::contract;
+    /// @cond IMPLEMENTATIONS
 
-         /**
-          * Create proposal
-          *
-          * @details Creates a proposal containing one transaction.
-          * Allows an account `proposer` to make a proposal `proposal_name` which has `requested`
-          * permission levels expected to approve the proposal, and if approved by all expected
-          * permission levels then `trx` transaction can we executed by this proposal.
-          * The `proposer` account is authorized and the `trx` transaction is verified if it was
-          * authorized by the provided keys and permissions, and if the proposal name doesn’t
-          * already exist; if all validations pass the `proposal_name` and `trx` trasanction are
-          * saved in the proposals table and the `requested` permission levels to the
-          * approvals table (for the `proposer` context).
-          * Storage changes are billed to `proposer`.
-          *
-          * @param proposer - The account proposing a transaction
-          * @param proposal_name - The name of the proposal (should be unique for proposer)
-          * @param requested - Permission levels expected to approve the proposal
-          * @param trx - Proposed transaction
-          */
-         [[eosio::action]]
-         void propose(ignore<name> proposer, ignore<name> proposal_name,
-               ignore<std::vector<permission_level>> requested, ignore<transaction> trx);
-         /**
-          * Approve proposal
-          *
-          * @details Approves an existing proposal
-          * Allows an account, the owner of `level` permission, to approve a proposal `proposal_name`
-          * proposed by `proposer`. If the proposal's requested approval list contains the `level`
-          * permission then the `level` permission is moved from internal `requested_approvals` list to
-          * internal `provided_approvals` list of the proposal, thus persisting the approval for
-          * the `proposal_name` proposal.
-          * Storage changes are billed to `proposer`.
-          *
-          * @param proposer - The account proposing a transaction
-          * @param proposal_name - The name of the proposal (should be unique for proposer)
-          * @param level - Permission level approving the transaction
-          * @param proposal_hash - Transaction's checksum
-          */
-         [[eosio::action]]
-         void approve( name proposer, name proposal_name, permission_level level,
-                       const eosio::binary_extension<eosio::checksum256>& proposal_hash );
-         /**
-          * Revoke proposal
-          *
-          * @details Revokes an existing proposal
-          * This action is the reverse of the `approve` action: if all validations pass
-          * the `level` permission is erased from internal `provided_approvals` and added to the internal
-          * `requested_approvals` list, and thus un-approve or revoke the proposal.
-          *
-          * @param proposer - The account proposing a transaction
-          * @param proposal_name - The name of the proposal (should be an existing proposal)
-          * @param level - Permission level revoking approval for proposal
-          */
-         [[eosio::action]]
-         void unapprove( name proposer, name proposal_name, permission_level level );
-         /**
-          * Cancel proposal
-          *
-          * @details Cancels an existing proposal
-          *
-          * @param proposer - The account proposing a transaction
-          * @param proposal_name - The name of the proposal (should be an existing proposal)
-          * @param canceler - The account cancelling the proposal (only the proposer can cancel an unexpired transaction, and the canceler has to be different than the proposer)
-          *
-          * Allows the `canceler` account to cancel the `proposal_name` proposal, created by a `proposer`,
-          * only after time has expired on the proposed transaction. It removes corresponding entries from
-          * internal proptable and from approval (or old approvals) tables as well.
-          */
-         [[eosio::action]]
-         void cancel( name proposer, name proposal_name, name canceler );
-         /**
-          * Execute proposal
-          *
-          * @details Allows an `executer` account to execute a proposal.
-          *
-          * Preconditions:
-          * - `executer` has authorization,
-          * - `proposal_name` is found in the proposals table,
-          * - all requested approvals are received,
-          * - proposed transaction is not expired,
-          * - and approval accounts are not found in invalidations table.
-          *
-          * If all preconditions are met the transaction is executed as a deferred transaction,
-          * and the proposal is erased from the proposals table.
-          *
-          * @param proposer - The account proposing a transaction
-          * @param proposal_name - The name of the proposal (should be an existing proposal)
-          * @param executer - The account executing the transaction
-          */
-         [[eosio::action]]
-         void exec( name proposer, name proposal_name, name executer );
-         /**
-          * Invalidate proposal
-          *
-          * @details Allows an `account` to invalidate itself, that is, its name is added to
-          * the invalidations table and this table will be cross referenced when exec is performed.
-          *
-          * @param account - The account invalidating the transaction
-          */
-         [[eosio::action]]
-         void invalidate( name account );
+    /**
+     * The `eosio.msig` system contract allows for creation of proposed transactions which require authorization from a list of accounts, approval of the proposed transactions by those accounts required to approve it, and finally, it also allows the execution of the approved transactions on the blockchain.
+     *
+     * In short, the workflow to propose, review, approve and then executed a transaction it can be described by the following:
+     * - first you create a transaction json file,
+     * - then you submit this proposal to the `eosio.msig` contract, and you also insert the account permissions required to approve this proposal into the command that submits the proposal to the blockchain,
+     * - the proposal then gets stored on the blockchain by the `eosio.msig` contract, and is accessible for review and approval to those accounts required to approve it,
+     * - after each of the appointed accounts required to approve the proposed transactions reviews and approves it, you can execute the proposed transaction. The `eosio.msig` contract will execute it automatically, but not before validating that the transaction has not expired, it is not cancelled, and it has been signed by all the permissions in the initial proposal's required permission list.
+     */
+    class [[eosio::contract("eosio.msig")]] multisig : public contract {
+    public:
+        using contract::contract;
 
-         using propose_action = eosio::action_wrapper<"propose"_n, &multisig::propose>;
-         using approve_action = eosio::action_wrapper<"approve"_n, &multisig::approve>;
-         using unapprove_action = eosio::action_wrapper<"unapprove"_n, &multisig::unapprove>;
-         using cancel_action = eosio::action_wrapper<"cancel"_n, &multisig::cancel>;
-         using exec_action = eosio::action_wrapper<"exec"_n, &multisig::exec>;
-         using invalidate_action = eosio::action_wrapper<"invalidate"_n, &multisig::invalidate>;
-      private:
-         struct [[eosio::table]] proposal {
-            name                            proposal_name;
-            std::vector<char>               packed_transaction;
+        /**
+         * Propose action, creates a proposal containing one transaction.
+         * Allows an account `proposer` to make a proposal `proposal_name` which has `requested`
+         * permission levels expected to approve the proposal, and if approved by all expected
+         * permission levels then `trx` transaction can we executed by this proposal.
+         * The `proposer` account is authorized and the `trx` transaction is verified if it was
+         * authorized by the provided keys and permissions, and if the proposal name doesn’t
+         * already exist; if all validations pass the `proposal_name` and `trx` trasanction are
+         * saved in the proposals table and the `requested` permission levels to the
+         * approvals table (for the `proposer` context). Storage changes are billed to `proposer`.
+         *
+         * @param proposer - The account proposing a transaction
+         * @param proposal_name - The name of the proposal (should be unique for proposer)
+         * @param requested - Permission levels expected to approve the proposal
+         * @param trx - Proposed transaction
+         */
+        [[eosio::action]]
+        void propose(name proposer, name proposal_name,
+                     std::vector<permission_level> requested, ignore<transaction> trx);
+        /**
+         * Approve action approves an existing proposal. Allows an account, the owner of `level` permission, to approve a proposal `proposal_name`
+         * proposed by `proposer`. If the proposal's requested approval list contains the `level`
+         * permission then the `level` permission is moved from internal `requested_approvals` list to
+         * internal `provided_approvals` list of the proposal, thus persisting the approval for
+         * the `proposal_name` proposal. Storage changes are billed to `proposer`.
+         *
+         * @param proposer - The account proposing a transaction
+         * @param proposal_name - The name of the proposal (should be unique for proposer)
+         * @param level - Permission level approving the transaction
+         * @param proposal_hash - Transaction's checksum
+         */
+        [[eosio::action]]
+        void approve( name proposer, name proposal_name, permission_level level,
+                      const eosio::binary_extension<eosio::checksum256>& proposal_hash );
+        /**
+         * Unapprove action revokes an existing proposal. This action is the reverse of the `approve` action: if all validations pass
+         * the `level` permission is erased from internal `provided_approvals` and added to the internal
+         * `requested_approvals` list, and thus un-approve or revoke the proposal.
+         *
+         * @param proposer - The account proposing a transaction
+         * @param proposal_name - The name of the proposal (should be an existing proposal)
+         * @param level - Permission level revoking approval for proposal
+         */
+        [[eosio::action]]
+        void unapprove( name proposer, name proposal_name, permission_level level );
+        /**
+         * Cancel action cancels an existing proposal.
+         *
+         * @param proposer - The account proposing a transaction
+         * @param proposal_name - The name of the proposal (should be an existing proposal)
+         * @param canceler - The account cancelling the proposal (only the proposer can cancel an unexpired transaction, and the canceler has to be different than the proposer)
+         *
+         * Allows the `canceler` account to cancel the `proposal_name` proposal, created by a `proposer`,
+         * only after time has expired on the proposed transaction. It removes corresponding entries from
+         * internal proptable and from approval (or old approvals) tables as well.
+         */
+        [[eosio::action]]
+        void cancel( name proposer, name proposal_name, name canceler );
+        /**
+         * Exec action allows an `executer` account to execute a proposal.
+         *
+         * Preconditions:
+         * - `executer` has authorization,
+         * - `proposal_name` is found in the proposals table,
+         * - all requested approvals are received,
+         * - proposed transaction is not expired,
+         * - and approval accounts are not found in invalidations table.
+         *
+         * If all preconditions are met the transaction is executed as a deferred transaction,
+         * and the proposal is erased from the proposals table.
+         *
+         * @param proposer - The account proposing a transaction
+         * @param proposal_name - The name of the proposal (should be an existing proposal)
+         * @param executer - The account executing the transaction
+         */
+        [[eosio::action]]
+        void exec( name proposer, name proposal_name, name executer );
+        /**
+         * Invalidate action allows an `account` to invalidate itself, that is, its name is added to
+         * the invalidations table and this table will be cross referenced when exec is performed.
+         *
+         * @param account - The account invalidating the transaction
+         */
+        [[eosio::action]]
+        void invalidate( name account );
 
-            uint64_t primary_key()const { return proposal_name.value; }
-         };
+        using propose_action = eosio::action_wrapper<"propose"_n, &multisig::propose>;
+        using approve_action = eosio::action_wrapper<"approve"_n, &multisig::approve>;
+        using unapprove_action = eosio::action_wrapper<"unapprove"_n, &multisig::unapprove>;
+        using cancel_action = eosio::action_wrapper<"cancel"_n, &multisig::cancel>;
+        using exec_action = eosio::action_wrapper<"exec"_n, &multisig::exec>;
+        using invalidate_action = eosio::action_wrapper<"invalidate"_n, &multisig::invalidate>;
+    };
 
-         typedef eosio::multi_index< "proposal"_n, proposal > proposals;
+    struct [[eosio::table, eosio::contract("eosio.msig")]] proposal {
+        name                                                            proposal_name;
+        std::vector<char>                                               packed_transaction;
+        eosio::binary_extension< std::optional<time_point> >            earliest_exec_time;
 
-         struct [[eosio::table]] old_approvals_info {
-            name                            proposal_name;
-            std::vector<permission_level>   requested_approvals;
-            std::vector<permission_level>   provided_approvals;
+        uint64_t primary_key()const { return proposal_name.value; }
+    };
+    typedef eosio::multi_index< "proposal"_n, proposal > proposals;
 
-            uint64_t primary_key()const { return proposal_name.value; }
-         };
-         typedef eosio::multi_index< "approvals"_n, old_approvals_info > old_approvals;
+    struct [[eosio::table, eosio::contract("eosio.msig")]] old_approvals_info {
+        name                            proposal_name;
+        std::vector<permission_level>   requested_approvals;
+        std::vector<permission_level>   provided_approvals;
 
-         struct approval {
-            permission_level level;
-            time_point       time;
-         };
+        uint64_t primary_key()const { return proposal_name.value; }
+    };
+    typedef eosio::multi_index< "approvals"_n, old_approvals_info > old_approvals;
 
-         struct [[eosio::table]] approvals_info {
-            uint8_t                 version = 1;
-            name                    proposal_name;
-            //requested approval doesn't need to cointain time, but we want requested approval
-            //to be of exact the same size ad provided approval, in this case approve/unapprove
-            //doesn't change serialized data size. So, we use the same type.
-            std::vector<approval>   requested_approvals;
-            std::vector<approval>   provided_approvals;
+    struct approval {
+        permission_level level;
+        time_point       time;
+    };
 
-            uint64_t primary_key()const { return proposal_name.value; }
-         };
-         typedef eosio::multi_index< "approvals2"_n, approvals_info > approvals;
+    struct [[eosio::table, eosio::contract("eosio.msig")]] approvals_info {
+        uint8_t                 version = 1;
+        name                    proposal_name;
+        //requested approval doesn't need to contain time, but we want requested approval
+        //to be of exactly the same size as provided approval, in this case approve/unapprove
+        //doesn't change serialized data size. So, we use the same type.
+        std::vector<approval>   requested_approvals;
+        std::vector<approval>   provided_approvals;
 
-         struct [[eosio::table]] invalidation {
-            name         account;
-            time_point   last_invalidation_time;
+        uint64_t primary_key()const { return proposal_name.value; }
+    };
+    typedef eosio::multi_index< "approvals2"_n, approvals_info > approvals;
 
-            uint64_t primary_key() const { return account.value; }
-         };
+    struct [[eosio::table, eosio::contract("eosio.msig")]] invalidation {
+        name         account;
+        time_point   last_invalidation_time;
 
-         typedef eosio::multi_index< "invals"_n, invalidation > invalidations;
-   };
-   /** @}*/ // end of @defgroup eosiomsig eosio.msig
+        uint64_t primary_key() const { return account.value; }
+    };
+    typedef eosio::multi_index< "invals"_n, invalidation > invalidations;
+
 } /// namespace eosio

--- a/contracts/eosio.msig/src/eosio.msig.cpp
+++ b/contracts/eosio.msig/src/eosio.msig.cpp
@@ -1,207 +1,273 @@
-#include <eosio.msig/eosio.msig.hpp>
-
 #include <eosio/action.hpp>
-#include <eosio/permission.hpp>
 #include <eosio/crypto.hpp>
+#include <eosio/permission.hpp>
+
+#include <eosio.msig/eosio.msig.hpp>
 
 namespace eosio {
 
-void multisig::propose( ignore<name> proposer,
-                        ignore<name> proposal_name,
-                        ignore<std::vector<permission_level>> requested,
-                        ignore<transaction> trx )
-{
-   name _proposer;
-   name _proposal_name;
-   std::vector<permission_level> _requested;
-   transaction_header _trx_header;
+    transaction_header get_trx_header(const char* ptr, size_t sz);
+    bool trx_is_authorized(const std::vector<permission_level>& approvals, const std::vector<char>& packed_trx);
 
-   _ds >> _proposer >> _proposal_name >> _requested;
+    template<typename Function>
+    std::vector<permission_level> get_approvals_and_adjust_table(name self, name proposer, name proposal_name, Function&& table_op) {
+        approvals approval_table( self, proposer.value );
+        auto approval_table_iter = approval_table.find( proposal_name.value );
+        std::vector<permission_level> approvals_vector;
+        invalidations invalidations_table( self, self.value );
 
-   const char* trx_pos = _ds.pos();
-   size_t size    = _ds.remaining();
-   _ds >> _trx_header;
+        if ( approval_table_iter != approval_table.end() ) {
+            approvals_vector.reserve( approval_table_iter->provided_approvals.size() );
+            for ( const auto& permission : approval_table_iter->provided_approvals ) {
+                auto iter = invalidations_table.find( permission.level.actor.value );
+                if ( iter == invalidations_table.end() || iter->last_invalidation_time < permission.time ) {
+                    approvals_vector.push_back(permission.level);
+                }
+            }
+            table_op( approval_table, approval_table_iter );
+        } else {
+            old_approvals old_approval_table( self, proposer.value );
+            const auto& old_approvals_obj = old_approval_table.get( proposal_name.value, "proposal not found" );
+            for ( const auto& permission : old_approvals_obj.provided_approvals ) {
+                auto iter = invalidations_table.find( permission.actor.value );
+                if ( iter == invalidations_table.end() ) {
+                    approvals_vector.push_back( permission );
+                }
+            }
+            table_op( old_approval_table, old_approvals_obj );
+        }
+        return approvals_vector;
+    }
 
-   require_auth( _proposer );
-   check( _trx_header.expiration >= eosio::time_point_sec(current_time_point()), "transaction expired" );
-   //check( trx_header.actions.size() > 0, "transaction must have at least one action" );
+    void multisig::propose( name proposer,
+                            name proposal_name,
+                            std::vector<permission_level> requested,
+                            ignore<transaction> trx )
+    {
+        require_auth( proposer );
+        auto& ds = get_datastream();
 
-   proposals proptable( get_self(), _proposer.value );
-   check( proptable.find( _proposal_name.value ) == proptable.end(), "proposal with the same name exists" );
+        const char* trx_pos = ds.pos();
+        size_t size = ds.remaining();
 
-   auto packed_requested = pack(_requested);
-   // TODO: Remove internal_use_do_not_use namespace after minimum eosio.cdt dependency becomes 1.7.x
-   auto res =  internal_use_do_not_use::check_transaction_authorization(
-                  trx_pos, size,
-                  (const char*)0, 0,
-                  packed_requested.data(), packed_requested.size()
-               );
-   check( res > 0, "transaction authorization failed" );
+        transaction_header trx_header;
+        std::vector<action> context_free_actions;
+        ds >> trx_header;
+        check( trx_header.expiration >= eosio::time_point_sec(current_time_point()), "transaction expired" );
+        ds >> context_free_actions;
+        check( context_free_actions.empty(), "not allowed to `propose` a transaction with context-free actions" );
 
-   std::vector<char> pkd_trans;
-   pkd_trans.resize(size);
-   memcpy((char*)pkd_trans.data(), trx_pos, size);
-   proptable.emplace( _proposer, [&]( auto& prop ) {
-      prop.proposal_name       = _proposal_name;
-      prop.packed_transaction  = pkd_trans;
-   });
+        proposals proptable( get_self(), proposer.value );
+        check( proptable.find( proposal_name.value ) == proptable.end(), "proposal with the same name exists" );
 
-   approvals apptable( get_self(), _proposer.value );
-   apptable.emplace( _proposer, [&]( auto& a ) {
-      a.proposal_name       = _proposal_name;
-      a.requested_approvals.reserve( _requested.size() );
-      for ( auto& level : _requested ) {
-         a.requested_approvals.push_back( approval{ level, time_point{ microseconds{0} } } );
-      }
-   });
-}
+        auto packed_requested = pack(requested);
+        auto res =  check_transaction_authorization(
+                trx_pos, size,
+                (const char*)0, 0,
+                packed_requested.data(), packed_requested.size()
+        );
 
-void multisig::approve( name proposer, name proposal_name, permission_level level,
-                        const eosio::binary_extension<eosio::checksum256>& proposal_hash )
-{
-   require_auth( level );
+        check( res > 0, "transaction authorization failed" );
 
-   if( proposal_hash ) {
-      proposals proptable( get_self(), proposer.value );
-      auto& prop = proptable.get( proposal_name.value, "proposal not found" );
-      assert_sha256( prop.packed_transaction.data(), prop.packed_transaction.size(), *proposal_hash );
-   }
+        std::vector<char> pkd_trans;
+        pkd_trans.resize(size);
+        memcpy((char*)pkd_trans.data(), trx_pos, size);
 
-   approvals apptable( get_self(), proposer.value );
-   auto apps_it = apptable.find( proposal_name.value );
-   if ( apps_it != apptable.end() ) {
-      auto itr = std::find_if( apps_it->requested_approvals.begin(), apps_it->requested_approvals.end(), [&](const approval& a) { return a.level == level; } );
-      check( itr != apps_it->requested_approvals.end(), "approval is not on the list of requested approvals" );
+        proptable.emplace( proposer, [&]( auto& prop ) {
+            prop.proposal_name      = proposal_name;
+            prop.packed_transaction = pkd_trans;
+            prop.earliest_exec_time.emplace();
+        });
 
-      apptable.modify( apps_it, proposer, [&]( auto& a ) {
-            a.provided_approvals.push_back( approval{ level, current_time_point() } );
-            a.requested_approvals.erase( itr );
-         });
-   } else {
-      old_approvals old_apptable( get_self(), proposer.value );
-      auto& apps = old_apptable.get( proposal_name.value, "proposal not found" );
+        approvals apptable( get_self(), proposer.value );
+        apptable.emplace( proposer, [&]( auto& a ) {
+            a.proposal_name = proposal_name;
+            a.requested_approvals.reserve( requested.size() );
+            for ( auto& level : requested ) {
+                a.requested_approvals.push_back( approval{ level, time_point{ microseconds{0} } } );
+            }
+        });
+    }
 
-      auto itr = std::find( apps.requested_approvals.begin(), apps.requested_approvals.end(), level );
-      check( itr != apps.requested_approvals.end(), "approval is not on the list of requested approvals" );
+    void multisig::approve( name proposer, name proposal_name, permission_level level,
+                            const eosio::binary_extension<eosio::checksum256>& proposal_hash )
+    {
+        require_auth( level );
 
-      old_apptable.modify( apps, proposer, [&]( auto& a ) {
-            a.provided_approvals.push_back( level );
-            a.requested_approvals.erase( itr );
-         });
-   }
-}
+        proposals proptable( get_self(), proposer.value );
+        auto& prop = proptable.get( proposal_name.value, "proposal not found" );
 
-void multisig::unapprove( name proposer, name proposal_name, permission_level level ) {
-   require_auth( level );
+        if( proposal_hash ) {
+            assert_sha256( prop.packed_transaction.data(), prop.packed_transaction.size(), *proposal_hash );
+        }
 
-   approvals apptable( get_self(), proposer.value );
-   auto apps_it = apptable.find( proposal_name.value );
-   if ( apps_it != apptable.end() ) {
-      auto itr = std::find_if( apps_it->provided_approvals.begin(), apps_it->provided_approvals.end(), [&](const approval& a) { return a.level == level; } );
-      check( itr != apps_it->provided_approvals.end(), "no approval previously granted" );
-      apptable.modify( apps_it, proposer, [&]( auto& a ) {
-            a.requested_approvals.push_back( approval{ level, current_time_point() } );
-            a.provided_approvals.erase( itr );
-         });
-   } else {
-      old_approvals old_apptable( get_self(), proposer.value );
-      auto& apps = old_apptable.get( proposal_name.value, "proposal not found" );
-      auto itr = std::find( apps.provided_approvals.begin(), apps.provided_approvals.end(), level );
-      check( itr != apps.provided_approvals.end(), "no approval previously granted" );
-      old_apptable.modify( apps, proposer, [&]( auto& a ) {
-            a.requested_approvals.push_back( level );
-            a.provided_approvals.erase( itr );
-         });
-   }
-}
+        approvals apptable( get_self(), proposer.value );
+        auto apps_it = apptable.find( proposal_name.value );
+        if ( apps_it != apptable.end() ) {
+            auto itr = std::find_if( apps_it->requested_approvals.begin(), apps_it->requested_approvals.end(), [&](const approval& a) { return a.level == level; } );
+            check( itr != apps_it->requested_approvals.end(), "approval is not on the list of requested approvals" );
 
-void multisig::cancel( name proposer, name proposal_name, name canceler ) {
-   require_auth( canceler );
+            apptable.modify( apps_it, proposer, [&]( auto& a ) {
+                a.provided_approvals.push_back( approval{ level, current_time_point() } );
+                a.requested_approvals.erase( itr );
+            });
+        } else {
+            old_approvals old_apptable( get_self(), proposer.value );
+            auto& apps = old_apptable.get( proposal_name.value, "proposal not found" );
 
-   proposals proptable( get_self(), proposer.value );
-   auto& prop = proptable.get( proposal_name.value, "proposal not found" );
+            auto itr = std::find( apps.requested_approvals.begin(), apps.requested_approvals.end(), level );
+            check( itr != apps.requested_approvals.end(), "approval is not on the list of requested approvals" );
 
-   if( canceler != proposer ) {
-      check( unpack<transaction_header>( prop.packed_transaction ).expiration < eosio::time_point_sec(current_time_point()), "cannot cancel until expiration" );
-   }
-   proptable.erase(prop);
+            old_apptable.modify( apps, proposer, [&]( auto& a ) {
+                a.provided_approvals.push_back( level );
+                a.requested_approvals.erase( itr );
+            });
+        }
 
-   //remove from new table
-   approvals apptable( get_self(), proposer.value );
-   auto apps_it = apptable.find( proposal_name.value );
-   if ( apps_it != apptable.end() ) {
-      apptable.erase(apps_it);
-   } else {
-      old_approvals old_apptable( get_self(), proposer.value );
-      auto apps_it = old_apptable.find( proposal_name.value );
-      check( apps_it != old_apptable.end(), "proposal not found" );
-      old_apptable.erase(apps_it);
-   }
-}
+        transaction_header trx_header = get_trx_header(prop.packed_transaction.data(), prop.packed_transaction.size());
 
-void multisig::exec( name proposer, name proposal_name, name executer ) {
-   require_auth( executer );
+        if( prop.earliest_exec_time.has_value() ) {
+            if( !prop.earliest_exec_time->has_value() ) {
+                auto table_op = [](auto&&, auto&&){};
+                if( trx_is_authorized(get_approvals_and_adjust_table(get_self(), proposer, proposal_name, table_op), prop.packed_transaction) ) {
+                    proptable.modify( prop, proposer, [&]( auto& p ) {
+                        p.earliest_exec_time.emplace(time_point{ current_time_point() + eosio::seconds(trx_header.delay_sec.value)});
+                    });
+                }
+            }
+        } else {
+            check( trx_header.delay_sec.value == 0, "old proposals are not allowed to have non-zero `delay_sec`; cancel and retry" );
+        }
+    }
 
-   proposals proptable( get_self(), proposer.value );
-   auto& prop = proptable.get( proposal_name.value, "proposal not found" );
-   transaction_header trx_header;
-   datastream<const char*> ds( prop.packed_transaction.data(), prop.packed_transaction.size() );
-   ds >> trx_header;
-   check( trx_header.expiration >= eosio::time_point_sec(current_time_point()), "transaction expired" );
+    void multisig::unapprove( name proposer, name proposal_name, permission_level level ) {
+        require_auth( level );
 
-   approvals apptable( get_self(), proposer.value );
-   auto apps_it = apptable.find( proposal_name.value );
-   std::vector<permission_level> approvals;
-   invalidations inv_table( get_self(), get_self().value );
-   if ( apps_it != apptable.end() ) {
-      approvals.reserve( apps_it->provided_approvals.size() );
-      for ( auto& p : apps_it->provided_approvals ) {
-         auto it = inv_table.find( p.level.actor.value );
-         if ( it == inv_table.end() || it->last_invalidation_time < p.time ) {
-            approvals.push_back(p.level);
-         }
-      }
-      apptable.erase(apps_it);
-   } else {
-      old_approvals old_apptable( get_self(), proposer.value );
-      auto& apps = old_apptable.get( proposal_name.value, "proposal not found" );
-      for ( auto& level : apps.provided_approvals ) {
-         auto it = inv_table.find( level.actor.value );
-         if ( it == inv_table.end() ) {
-            approvals.push_back( level );
-         }
-      }
-      old_apptable.erase(apps);
-   }
-   auto packed_provided_approvals = pack(approvals);
-   // TODO: Remove internal_use_do_not_use namespace after minimum eosio.cdt dependency becomes 1.7.x
-   auto res =  internal_use_do_not_use::check_transaction_authorization(
-                  prop.packed_transaction.data(), prop.packed_transaction.size(),
-                  (const char*)0, 0,
-                  packed_provided_approvals.data(), packed_provided_approvals.size()
-               );
-   check( res > 0, "transaction authorization failed" );
+        approvals apptable( get_self(), proposer.value );
+        auto apps_it = apptable.find( proposal_name.value );
+        if ( apps_it != apptable.end() ) {
+            auto itr = std::find_if( apps_it->provided_approvals.begin(), apps_it->provided_approvals.end(), [&](const approval& a) { return a.level == level; } );
+            check( itr != apps_it->provided_approvals.end(), "no approval previously granted" );
+            apptable.modify( apps_it, proposer, [&]( auto& a ) {
+                a.requested_approvals.push_back( approval{ level, current_time_point() } );
+                a.provided_approvals.erase( itr );
+            });
+        } else {
+            old_approvals old_apptable( get_self(), proposer.value );
+            auto& apps = old_apptable.get( proposal_name.value, "proposal not found" );
+            auto itr = std::find( apps.provided_approvals.begin(), apps.provided_approvals.end(), level );
+            check( itr != apps.provided_approvals.end(), "no approval previously granted" );
+            old_apptable.modify( apps, proposer, [&]( auto& a ) {
+                a.requested_approvals.push_back( level );
+                a.provided_approvals.erase( itr );
+            });
+        }
 
-   send_deferred( (uint128_t(proposer.value) << 64) | proposal_name.value, executer,
-                  prop.packed_transaction.data(), prop.packed_transaction.size() );
+        proposals proptable( get_self(), proposer.value );
+        auto& prop = proptable.get( proposal_name.value, "proposal not found" );
 
-   proptable.erase(prop);
-}
+        if( prop.earliest_exec_time.has_value() ) {
+            if( prop.earliest_exec_time->has_value() ) {
+                auto table_op = [](auto&&, auto&&){};
+                if( !trx_is_authorized(get_approvals_and_adjust_table(get_self(), proposer, proposal_name, table_op), prop.packed_transaction) ) {
+                    proptable.modify( prop, proposer, [&]( auto& p ) {
+                        p.earliest_exec_time.emplace();
+                    });
+                }
+            }
+        } else {
+            transaction_header trx_header = get_trx_header(prop.packed_transaction.data(), prop.packed_transaction.size());
+            check( trx_header.delay_sec.value == 0, "old proposals are not allowed to have non-zero `delay_sec`; cancel and retry" );
+        }
+    }
 
-void multisig::invalidate( name account ) {
-   require_auth( account );
-   invalidations inv_table( get_self(), get_self().value );
-   auto it = inv_table.find( account.value );
-   if ( it == inv_table.end() ) {
-      inv_table.emplace( account, [&](auto& i) {
-            i.account = account;
-            i.last_invalidation_time = current_time_point();
-         });
-   } else {
-      inv_table.modify( it, account, [&](auto& i) {
-            i.last_invalidation_time = current_time_point();
-         });
-   }
-}
+    void multisig::cancel( name proposer, name proposal_name, name canceler ) {
+        require_auth( canceler );
+
+        proposals proptable( get_self(), proposer.value );
+        auto& prop = proptable.get( proposal_name.value, "proposal not found" );
+
+        if( canceler != proposer ) {
+            check( unpack<transaction_header>( prop.packed_transaction ).expiration < eosio::time_point_sec(current_time_point()), "cannot cancel until expiration" );
+        }
+        proptable.erase(prop);
+
+        //remove from new table
+        approvals apptable( get_self(), proposer.value );
+        auto apps_it = apptable.find( proposal_name.value );
+        if ( apps_it != apptable.end() ) {
+            apptable.erase(apps_it);
+        } else {
+            old_approvals old_apptable( get_self(), proposer.value );
+            auto apps_it = old_apptable.find( proposal_name.value );
+            check( apps_it != old_apptable.end(), "proposal not found" );
+            old_apptable.erase(apps_it);
+        }
+    }
+
+    void multisig::exec( name proposer, name proposal_name, name executer ) {
+        require_auth( executer );
+
+        proposals proptable( get_self(), proposer.value );
+        auto& prop = proptable.get( proposal_name.value, "proposal not found" );
+
+        datastream<const char*> ds = {prop.packed_transaction.data(), prop.packed_transaction.size()};
+        transaction_header trx_header;
+        std::vector<action> context_free_actions;
+        std::vector<action> actions;
+        ds >> trx_header;
+        check( trx_header.expiration >= eosio::time_point_sec(current_time_point()), "transaction expired" );
+        ds >> context_free_actions;
+        check( context_free_actions.empty(), "not allowed to `exec` a transaction with context-free actions" );
+        ds >> actions;
+
+        auto table_op = [](auto&& table, auto&& table_iter) { table.erase(table_iter); };
+        bool ok = trx_is_authorized(get_approvals_and_adjust_table(get_self(), proposer, proposal_name, table_op), prop.packed_transaction);
+        check( ok, "transaction authorization failed" );
+
+        if ( prop.earliest_exec_time.has_value() && prop.earliest_exec_time->has_value() ) {
+            check( **prop.earliest_exec_time <= current_time_point(), "too early to execute" );
+        } else {
+            check( trx_header.delay_sec.value == 0, "old proposals are not allowed to have non-zero `delay_sec`; cancel and retry" );
+        }
+
+        for (const auto& act : actions) {
+            act.send();
+        }
+
+        proptable.erase(prop);
+    }
+
+    void multisig::invalidate( name account ) {
+        require_auth( account );
+        invalidations inv_table( get_self(), get_self().value );
+        auto it = inv_table.find( account.value );
+        if ( it == inv_table.end() ) {
+            inv_table.emplace( account, [&](auto& i) {
+                i.account = account;
+                i.last_invalidation_time = current_time_point();
+            });
+        } else {
+            inv_table.modify( it, account, [&](auto& i) {
+                i.last_invalidation_time = current_time_point();
+            });
+        }
+    }
+
+    transaction_header get_trx_header(const char* ptr, size_t sz) {
+        datastream<const char*> ds = {ptr, sz};
+        transaction_header trx_header;
+        ds >> trx_header;
+        return trx_header;
+    }
+
+    bool trx_is_authorized(const std::vector<permission_level>& approvals, const std::vector<char>& packed_trx) {
+        auto packed_approvals = pack(approvals);
+        return check_transaction_authorization(
+                packed_trx.data(), packed_trx.size(),
+                (const char*)0, 0,
+                packed_approvals.data(), packed_approvals.size()
+        );
+    }
 
 } /// namespace eosio


### PR DESCRIPTION
Alignment of eosio.msig with tag `v1.8.3-inline-msig-patch3` of eosio.contacts.  The current version deployed and tested on EOS mainnet which removes the deferred tranaction is `v1.8.3-inline-msig-patch2` but this patch3 is the advised version and has insignificant CDT related differences with patch2.