### PR TITLE
Disable the creation of accounts starting with `ibc`

### DIFF
--- a/contracts/eosio.system/src/eosio.system.cpp
+++ b/contracts/eosio.system/src/eosio.system.cpp
@@ -453,6 +453,14 @@ namespace eosiosystem {
                             ignore<authority> owner,
                             ignore<authority> active ) {
 
+      // BEGIN TELOS
+      if (!has_auth(_self))
+          check(
+              new_account_name.to_string().find("ibc.", 0, 4) != 0,
+              "only eosio can create names that start with 'ibc.'"
+          );
+      // END TELOS
+
       if( creator != get_self() ) {
          uint64_t tmp = new_account_name.value >> 4;
          bool has_dot = false;

--- a/tests/telos.system_tests.cpp
+++ b/tests/telos.system_tests.cpp
@@ -387,4 +387,20 @@ BOOST_FIXTURE_TEST_CASE(multi_producer_pay, eosio_system_tester, * boost::unit_t
    }
 } FC_LOG_AND_RETHROW()
 
+BOOST_FIXTURE_TEST_CASE( ibc_new_account, eosio_system_tester ) try {
+
+    // fail if alice tries
+    BOOST_REQUIRE_EXCEPTION(
+        create_account_with_resources("ibc.testing"_n, "alice1111111"_n),
+        eosio_assert_message_exception,
+        eosio_assert_message_is("only eosio can create names that start with 'ibc.'")
+    );
+
+    // success if sudo account tries
+    BOOST_REQUIRE_EQUAL(
+        false,
+        create_account_with_resources("ibc.testing"_n, "eosio"_n)->except.has_value());
+
+} FC_LOG_AND_RETHROW()
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

Closes #38 

## Change Description
If any user (except `eosio`) calls `newaccount` it will fail and raise an error message. This is necessary to reserve the names for the new inter blockchain communication initiative.
