### PR TITLE
Reduce standby producers to 14

### DIFF
--- a/contracts/eosio.system/src/producer_pay.cpp
+++ b/contracts/eosio.system/src/producer_pay.cpp
@@ -4,7 +4,7 @@
 #include <eosio.tedp/eosio.tedp.hpp>
 #include <delphioracle/delphioracle.hpp>
 #include "system_kick.cpp"
-#define MAX_PRODUCERS 42     // revised for TEDP 2 Phase 2, also set in system_rotation.cpp, change in both places
+#define MAX_PRODUCERS 35     // revised for TEDP 2 Phase 2, also set in system_rotation.cpp, change in both places
 // TELOS END
 
 namespace eosiosystem {
@@ -368,7 +368,7 @@ namespace eosiosystem {
         // activecount = 21: 42
         // activecount = 22: 43.2
         // ...
-        // activecount = 42: 63
+        // activecount = 35: 56.98
         double sum_of_multipliers = activecount <= 21 ? (((activecount)/2)*(2*1.2-(activecount-1)*0.02) * 2) : (42 + ((activecount-21)/2)*(2*1.2-(activecount-22)*0.02));
 
         auto shareValue = (_gstate.perblock_bucket / sum_of_multipliers);
@@ -386,7 +386,7 @@ namespace eosiosystem {
                 // Applying tiered BP pay multiplier for active BPs (rank 1st until 21st) [1.2, 1.18, ... , 0.82, 0.8] multiplied by 2
                 pay_amount = (shareValue * int64_t(2) * ((122-2*index)/100.0));
             } else if (index >= 22 && index <= MAX_PRODUCERS) {
-                // Applying tiered BP pay multiplier for standby BPs (rank 22nd until 42nd) [1.2, 1.18, ... , 0.82, 0.8] multiplied by 1
+                // Applying tiered BP pay multiplier for standby BPs (rank 22nd until 35th) [1.2, 1.18, ... , 0.96, 0.94] multiplied by 1
                 pay_amount = shareValue * ((164-2*index)/100.0);
             } else 
                 break;

--- a/contracts/eosio.system/src/system_rotation.cpp
+++ b/contracts/eosio.system/src/system_rotation.cpp
@@ -5,7 +5,7 @@
 #define ONE_HOUR_US 900000000       // debug version
 #define SIX_MINUTES_US 360000000    // debug version
 #define TWELVE_MINUTES_US 720000000 // debug version
-#define MAX_PRODUCERS 42     // revised for TEDP 2 Phase 2, also set in producer_pay.cpp, change in both places
+#define MAX_PRODUCERS 35     // revised for TEDP 2 Phase 2, also set in producer_pay.cpp, change in both places
 #define TOP_PRODUCERS 21
 #define MAX_VOTE_PRODUCERS 30
 

--- a/tests/telos.system_tests.cpp
+++ b/tests/telos.system_tests.cpp
@@ -2,7 +2,7 @@
 
 #include "eosio.system_tester.hpp"
 
-#define MAX_PRODUCERS 42
+#define MAX_PRODUCERS 35
 
 using namespace eosio_system;
 


### PR DESCRIPTION
DON'T MERGE UNTIL #54 IS MERGED

This pull request updates the maximum number of block producers from 42 to 35 across the system contract codebase and related tests. The changes ensure consistency in producer count definitions and update related logic and comments for clarity.

Producer count update:

* Changed the `MAX_PRODUCERS` definition from 42 to 35 in `producer_pay.cpp`, `system_rotation.cpp`, and the test file `telos.system_tests.cpp` to ensure consistent producer limits throughout the system. [[1]](diffhunk://#diff-0f3deba64a52f4175ea9a4a3c53a4d85a4f9fddf08869f37f1e116d414609ec3L7-R7) [[2]](diffhunk://#diff-e97d9a2fca51e0792cdb10c168ccfa0ed386bae916a92e9e4c524941caefacffL8-R8) [[3]](diffhunk://#diff-4ede209c5b161a307b2fad09393974c4eadb30278494ec08d083d3c6912f906eL5-R5)

Producer pay logic and documentation:

* Updated the comments and logic for producer pay multipliers in `producer_pay.cpp` to reflect the new range for standby block producers (now ranks 22nd to 35th) and adjusted example values accordingly. [[1]](diffhunk://#diff-0f3deba64a52f4175ea9a4a3c53a4d85a4f9fddf08869f37f1e116d414609ec3L371-R371) [[2]](diffhunk://#diff-0f3deba64a52f4175ea9a4a3c53a4d85a4f9fddf08869f37f1e116d414609ec3L389-R389)