### PR TITLE
Restrict distviarex to TEDP account

### DIFF
--- a/contracts/eosio.system/src/eosio.system.cpp
+++ b/contracts/eosio.system/src/eosio.system.cpp
@@ -578,6 +578,8 @@ namespace eosiosystem {
    }
 
    void system_contract::distviarex(name from, asset amount) {
+      check(from == tedp_account, "distviarex may only distribute TEDP funds");
+      require_auth(tedp_account);
       system_contract::channel_to_rex(from, amount);
    }
 


### PR DESCRIPTION
## Summary

Adds the deployed `distviarex` hotfix on top of the now-updated `main` branch.

`distviarex(from, amount)` is restricted to intended TEDP use only:

```cpp
check(from == tedp_account, "distviarex may only distribute TEDP funds");
require_auth(tedp_account);
```

where `tedp_account` is `exrsrv.tf`.

## Verification

This is the same source change used for the executed mainnet hotfix.

Mainnet execution transaction:

https://explorer.telos.net/transaction/e5318e118963a4689a7ee1cc631ad297adc0b6a4b314ed83a8634f407c0d61e2

Live mainnet `eosio` code hash after execution:

`02bac64cd7e3fa38e8b34c772ca47b82fe4a3b0c752ad2d8b97ef7ceb752afc8`

Post-deploy checks confirmed that arbitrary-account use now fails and `from = exrsrv.tf` still requires `exrsrv.tf` authority.