### PR TITLE
Fix stale BP rotation duplicate schedules

### DIFF
--- a/contracts/eosio.system/src/system_rotation.cpp
+++ b/contracts/eosio.system/src/system_rotation.cpp
@@ -100,6 +100,17 @@ std::vector<producer_location_pair> system_contract::check_rotation_state( std::
       std::vector<producer_location_pair>::iterator it_bp = prods.end();
       std::vector<producer_location_pair>::iterator it_sbp = prods.end();
 
+      auto clear_rotation = [&]() {
+        set_bps_rotation(name(0), name(0));
+        it_bp = prods.end();
+        it_sbp = prods.end();
+
+        if(total_active_voted_prods <= TOP_PRODUCERS) {
+          _grotation.bp_out_index = TOP_PRODUCERS;
+          _grotation.sbp_in_index = MAX_PRODUCERS+1;
+        }
+      };
+
       if (_grotation.next_rotation_time <= block_time) {
 
         if (total_active_voted_prods > TOP_PRODUCERS) {
@@ -113,13 +124,17 @@ std::vector<producer_location_pair> system_contract::check_rotation_state( std::
           it_sbp = prods.begin() + int32_t(_grotation.sbp_in_index);
 
           set_bps_rotation(bp_name, sbp_name);
-        } 
+        } else {
+          clear_rotation();
+        }
 
         update_rotation_time(block_time);
         restart_missed_blocks_per_rotation(prods);
       }
       else {
-        if(_grotation.bp_currently_out != name(0) && _grotation.sbp_currently_in != name(0)) {
+        if(total_active_voted_prods <= TOP_PRODUCERS) {
+          clear_rotation();
+        } else if(_grotation.bp_currently_out != name(0) && _grotation.sbp_currently_in != name(0)) {
           auto bp_name = _grotation.bp_currently_out;
           it_bp = std::find_if(prods.begin(), prods.end(), [&bp_name](const producer_location_pair &g) {
             return g.first.producer_name == bp_name; 
@@ -133,17 +148,9 @@ std::vector<producer_location_pair> system_contract::check_rotation_state( std::
           auto _sbp_index = std::distance(prods.begin(), it_sbp);
 
           if(it_bp == prods.end() || it_sbp == prods.end()) {
-              set_bps_rotation(name(0), name(0));
-
-            if(total_active_voted_prods < TOP_PRODUCERS) {
-              _grotation.bp_out_index = TOP_PRODUCERS;
-              _grotation.sbp_in_index = MAX_PRODUCERS+1;
-            }
-          } else if (total_active_voted_prods > TOP_PRODUCERS && 
-                    (!is_in_range(_bp_index, 0, TOP_PRODUCERS) || !is_in_range(_sbp_index, TOP_PRODUCERS, MAX_PRODUCERS))) {
-              set_bps_rotation(name(0), name(0));
-              it_bp = prods.end();
-              it_sbp = prods.end();
+              clear_rotation();
+          } else if (!is_in_range(_bp_index, 0, TOP_PRODUCERS) || !is_in_range(_sbp_index, TOP_PRODUCERS, MAX_PRODUCERS)) {
+              clear_rotation();
           }
         }
     }

--- a/tests/telos.system_tests.cpp
+++ b/tests/telos.system_tests.cpp
@@ -1,5 +1,6 @@
 #include <boost/test/unit_test.hpp>
 #include <cmath>
+#include <set>
 
 #include "eosio.system_tester.hpp"
 
@@ -125,6 +126,61 @@ BOOST_FIXTURE_TEST_CASE(producer_onblock_check, eosio_system_tester) try {
 
    BOOST_CHECK_EQUAL( success(), unstake( "producvotera", core_sym::from_string("50.0000"), core_sym::from_string("50.0000") ) );
 
+} FC_LOG_AND_RETHROW()
+
+BOOST_FIXTURE_TEST_CASE(rotation_clears_when_standby_moves_into_top_21, eosio_system_tester) try {
+   const asset large_asset = core_sym::from_string("80.0000");
+   create_account_with_resources( "rotvoter1111"_n, config::system_account_name, core_sym::from_string("1.0000"), false, large_asset, large_asset );
+
+   std::vector<account_name> producer_names;
+   producer_names.reserve(22);
+   const std::string root("rprod");
+   for(uint8_t i = 0; i < 22; i++) {
+      producer_names.emplace_back(root + toBase31(i));
+   }
+
+   setup_producer_accounts(producer_names);
+   for (const auto& p: producer_names) {
+      BOOST_REQUIRE_EQUAL(success(), regproducer(p));
+   }
+
+   transfer(config::system_account_name, "rotvoter1111"_n, core_sym::from_string("400000000.0000"), config::system_account_name);
+   BOOST_REQUIRE_EQUAL(success(), stake("rotvoter1111"_n, core_sym::from_string("150000000.0000"), core_sym::from_string("150000000.0000")));
+   BOOST_REQUIRE_EQUAL(success(), vote("rotvoter1111"_n, producer_names));
+
+   activate_network();
+   produce_blocks(250);
+
+   auto rotation = get_rotation_state();
+   const name bp_out = rotation["bp_currently_out"].as<name>();
+   const name sbp_in = rotation["sbp_currently_in"].as<name>();
+   BOOST_REQUIRE_NE(name(0), bp_out);
+   BOOST_REQUIRE_NE(name(0), sbp_in);
+
+   name removed_producer = name(0);
+   for (const auto& p: producer_names) {
+      if (p != bp_out && p != sbp_in) {
+         removed_producer = p;
+         break;
+      }
+   }
+   BOOST_REQUIRE_NE(name(0), removed_producer);
+   BOOST_REQUIRE_EQUAL(success(), push_action(removed_producer, "unregprod"_n, mvo()("producer", removed_producer)));
+
+   produce_block(fc::minutes(2));
+   produce_blocks(1);
+
+   rotation = get_rotation_state();
+   BOOST_REQUIRE_EQUAL(name(0), rotation["bp_currently_out"].as<name>());
+   BOOST_REQUIRE_EQUAL(name(0), rotation["sbp_currently_in"].as<name>());
+
+   const auto active_schedule = control->head_block_state()->active_schedule.producers;
+   std::set<name> scheduled_producers;
+   for (const auto& producer: active_schedule) {
+      scheduled_producers.insert(producer.producer_name);
+   }
+
+   BOOST_REQUIRE_EQUAL(active_schedule.size(), scheduled_producers.size());
 } FC_LOG_AND_RETHROW()
 
 BOOST_FIXTURE_TEST_CASE(producer_pay, eosio_system_tester, * boost::unit_test::tolerance(1e-10)) try {


### PR DESCRIPTION
## Summary
- Clear persisted BP/SBP rotation state whenever the active voted set has no standby range outside the top 21.
- Prevent stale rotation substitution from proposing a producer schedule with the same producer twice.
- Add a Telos system regression test for the exact 22 -> 21 active-voted-producer case.

## Root Cause
A previous rotation can leave `bp_currently_out` and `sbp_currently_in` set. If the producer set later shrinks to exactly 21 active voted producers, the standby producer can move into the top 21. The old code skipped range validation when `total_active_voted_prods <= TOP_PRODUCERS`, so it reused the stale SBP and proposed a duplicate producer schedule.

## Validation
- `git diff --check HEAD~1 HEAD`
- Docker workflow image configure: `apm2006/leap:v3.2.5-cdt4.0.1`, `cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=yes -Dleap_DIR=/opt/leap/build/lib/cmake/leap ..`
- Docker workflow image build: `make -j 4 VERBOSE=1`
- `ctest -R telos_system_unit_test --output-on-failure` passed
- `./unit_test --run_test=telos_system_tests/rotation_clears_when_standby_moves_into_top_21 --report_level=detailed` passed, 84/84 assertions

## Local Test Note
Full local `ctest -j 4 --output-on-failure` was also attempted under the amd64 Docker image on Apple Silicon. `telos_system_unit_test`, `eosio_system_unit_test`, `eosio_system_limitauth_unit_test`, and `eosio_system_blockinfo_unit_test` passed. Three unrelated suites failed at startup with the same WASM access violation: `eosio_msig_unit_test`, `eosio_token_unit_test`, and `eosio_wrap_unit_test`. Those failures occur outside this touched area and appear to be local emulation/container related.